### PR TITLE
fixed get_embedding() in ml/preprocessing.py

### DIFF
--- a/pagodas/ml/preprocessing.py
+++ b/pagodas/ml/preprocessing.py
@@ -76,7 +76,7 @@ def get_embedding( sequence : str,
 
 
     # Replace rare amino acids in sequence with X (aka "any")
-    seq_processed = " ".join(re.sub(r'[UZOB]', 'X', sequence))
+    seq_processed = [" ".join(re.sub(r'[UZOB]', 'X', sequence))]
 
     # Encode sequence with tokenizer
     ids = tokenizer.batch_encode_plus(seq_processed,
@@ -96,4 +96,4 @@ def get_embedding( sequence : str,
     # in the batch and remove padded & special tokens ([0,:7])
     embedding_output = [np.mean(e, axis=0) for e in embedding_repr.last_hidden_state] # [0] is the embedding output, others are attention layers
 
-    return embedding_output
+    return embedding_output[0]


### PR DESCRIPTION
I fixed the get_embeddings() function in ml/preprocessing.py that was sending back arrays that did not match those from Sergei. It took me some time to figure out what ws happening and I got the wrong lead a couple times but I finally found the culprit 👍 

I tested the function with the first protein of the dataset and compared it to Sergei's dataset:
- the np.allclose() function does NOT return True; however, I suspect it is due to the precision threshold that the function uses
- when using np.isclose(), we get about 99.1% values that are equal (this was both with our embedding and also comparing Sergei's embedding function to his dataset)

Here the kaggle notebook with the info if anyone's interested: https://www.kaggle.com/vembe06/sergei-embedding-check/

ps: If I remember correctly, there's also a bug with saving the model to local (on the VM for example), I'll check it out next, that way we'll have an API that is fully functional and doesn't need to load the model from the web each time

See you guys soon 💯 